### PR TITLE
Scale height for custom buttons, so the bottom of tall buttons react to click events

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you get the error `[GSI_LOGGER]: The given origin is not allowed for the give
 
 - For the ios platform, you need to create a client ID of type iOS in the [Google Cloud Console](https://console.cloud.google.com/apis/dashboard). Add the client ID to the  `{your-app}/ios/App/App/Info.plist` file with the key `GIDClientID` (see the demo app for reference). When creating the client ID, you will see the "iOS URL scheme" value in the Google Cloud Console. Add this also to the `Info.plist` file.
 
-After some testing the Chrome browser may decide to block third-party sign-in promts on localhost. In the browser console you will see the message *Third-party sign in was disabled in browser Site Settings*. Re-enable it under `chrome://settings/content/federatedIdentityApi`.
+After some testing the Chrome browser may decide to block third-party sign-in prompts on localhost. In the browser console you will see the message *Third-party sign in was disabled in browser Site Settings*. Re-enable it under `chrome://settings/content/federatedIdentityApi`.
 
 #### FAQ
 - How to see and disconnect the link between your google account and your app?  

--- a/src/GoogleSignIn.ts
+++ b/src/GoogleSignIn.ts
@@ -252,29 +252,28 @@ class GoogleSignIn implements GoogleOneTapAuthPlugin {
     assert(() => buttonElemWidth !== 0);
     assert(() => buttonElemHeight !== 0);
 
-    // Since we can't set the height on the Google sign-in button, we'll just scale everything up, and adjust its width
-    const googleButtonHeight = 40;
-    const scale = buttonElemHeight / googleButtonHeight;
-    const effectiveWidth = buttonElemWidth / scale;
-
     const invisibleGoogleButtonDiv = document.createElement('div');
     const invisibleGoogleButtonDivId = 'invisibleGoogleButtonDiv';
     invisibleGoogleButtonDiv.setAttribute('id', invisibleGoogleButtonDivId);
     invisibleGoogleButtonDiv.style.position = 'absolute';
     invisibleGoogleButtonDiv.style.top = '0px';
     invisibleGoogleButtonDiv.style.left = '0px';
-    invisibleGoogleButtonDiv.style.width = `${effectiveWidth}px`;
+    invisibleGoogleButtonDiv.style.width = `${buttonElemWidth}px`;
     invisibleGoogleButtonDiv.style.boxSizing = 'border-box';
     invisibleGoogleButtonDiv.style.opacity = '0.0001'; // change it for debugging
 
-    // Scale the invisible button so that the clickable area will be tall enough, such as if our button has vertical
-    // padding. Otherwise, the button of our button may not respond to clicks.
-    invisibleGoogleButtonDiv.style.transformOrigin = 'top left';
-    invisibleGoogleButtonDiv.style.transform = 'scale(' + scale + ')';
-
     buttonElem!.appendChild(invisibleGoogleButtonDiv);
 
-    await this.renderSignInButtonUsingGoogleIdentityServicesForWeb(onResult, invisibleGoogleButtonDivId, {}, { type: 'standard', width: effectiveWidth });
+    // Since we can't set the height on the Google sign-in button, we'll just scale everything up vertically.
+    const googleButtonHeight = 40;
+    const scaleY = buttonElemHeight / googleButtonHeight;
+
+    // Scale the invisible button so that the clickable area will be tall enough, such as if our button has vertical
+    // padding. Otherwise, the bottom of our button may not respond to clicks.
+    invisibleGoogleButtonDiv.style.transformOrigin = 'top left';
+    invisibleGoogleButtonDiv.style.transform = 'scale(1, ' + scaleY + ')';
+
+    await this.renderSignInButtonUsingGoogleIdentityServicesForWeb(onResult, invisibleGoogleButtonDivId, {}, { type: 'standard', width: buttonElemWidth });
   }
 
   private waitForElementOffsetWidthNotZero(element: HTMLElement): Promise<ElementOffsetSize> {

--- a/src/GoogleSignIn.ts
+++ b/src/GoogleSignIn.ts
@@ -252,6 +252,10 @@ class GoogleSignIn implements GoogleOneTapAuthPlugin {
     assert(() => buttonElemWidth !== 0);
     assert(() => buttonElemHeight !== 0);
 
+    // We can't set the height on the Google sign-in button, but scaling the parent element vertically has the same effect.
+    const googleButtonHeight = 40;
+    const scaleY = buttonElemHeight / googleButtonHeight;
+
     const invisibleGoogleButtonDiv = document.createElement('div');
     const invisibleGoogleButtonDivId = 'invisibleGoogleButtonDiv';
     invisibleGoogleButtonDiv.setAttribute('id', invisibleGoogleButtonDivId);
@@ -261,17 +265,10 @@ class GoogleSignIn implements GoogleOneTapAuthPlugin {
     invisibleGoogleButtonDiv.style.width = `${buttonElemWidth}px`;
     invisibleGoogleButtonDiv.style.boxSizing = 'border-box';
     invisibleGoogleButtonDiv.style.opacity = '0.0001'; // change it for debugging
-
-    buttonElem!.appendChild(invisibleGoogleButtonDiv);
-
-    // Since we can't set the height on the Google sign-in button, we'll just scale everything up vertically.
-    const googleButtonHeight = 40;
-    const scaleY = buttonElemHeight / googleButtonHeight;
-
-    // Scale the invisible button so that the clickable area will be tall enough, such as if our button has vertical
-    // padding. Otherwise, the bottom of our button may not respond to clicks.
     invisibleGoogleButtonDiv.style.transformOrigin = 'top left';
     invisibleGoogleButtonDiv.style.transform = 'scale(1, ' + scaleY + ')';
+
+    buttonElem!.appendChild(invisibleGoogleButtonDiv);
 
     await this.renderSignInButtonUsingGoogleIdentityServicesForWeb(onResult, invisibleGoogleButtonDivId, {}, { type: 'standard', width: buttonElemWidth });
   }


### PR DESCRIPTION
For custom buttons, scale the Google Sign-In button via `transform` since we can't set its `height`. It's invisible, so it won't have an impact on the appearance, but taller custom buttons will now be clickable at the bottom of the button.